### PR TITLE
feat: implement loading more && scroll up logic

### DIFF
--- a/src/assets/libs/api.ts
+++ b/src/assets/libs/api.ts
@@ -18,9 +18,9 @@ interface ProductResponse {
 
 export const fetchProducts = async (): Promise<ProductResponse> => {
   try {
-    const response = await fetch("https://dummyjson.com/products");
+    const response = await fetch("https://dummyjson.com/products?&limit=100");
     if (!response.ok) {
-      throw new Error("Failed to fetch products");
+      throw new Error("Error fetching");
     }
     const data = await response.json();
     return data as ProductResponse;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 import styled from "styled-components";
-import { Link } from "react-router-dom";
 
 interface ButtonProps {
-  path: string;
   text: string;
+  onClick?: () => void;
 }
-
-const BtnLink = styled(Link)`
-  text-decoration: none;
-`;
 
 const Wrapper = styled.div`
   position: relative;
@@ -19,6 +14,7 @@ const Wrapper = styled.div`
   padding: 0.8rem 2.4rem 0.8rem 2.4rem;
   background-color: #4f5153;
   border-radius: 20rem;
+  cursor: pointer;
 `;
 
 const Text = styled.div`
@@ -46,13 +42,11 @@ const Text = styled.div`
   }
 `;
 
-const Button: React.FC<ButtonProps> = ({ path, text }) => {
+const Button: React.FC<ButtonProps> = ({ text, onClick }) => {
   return (
-    <BtnLink to={path}>
-      <Wrapper>
-        <Text>{text}</Text>
-      </Wrapper>
-    </BtnLink>
+    <Wrapper onClick={onClick}>
+      <Text>{text}</Text>
+    </Wrapper>
   );
 };
 

--- a/src/pages/Info/Info.tsx
+++ b/src/pages/Info/Info.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import styled from "styled-components";
 import Header from "../../components/Header/Header";
 import Button from "../../components/Button/Button";
@@ -11,6 +11,10 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+`;
+
+const BtnLink = styled(Link)`
+  text-decoration: none;
 `;
 
 const BtnWrapper = styled.div`
@@ -271,7 +275,9 @@ const Info: React.FC = () => {
       <Header />
       <Wrapper>
         <BtnWrapper>
-          <Button path="/" text="목록으로 돌아가기" />
+          <BtnLink to="/">
+            <Button text="목록으로 돌아가기" />
+          </BtnLink>
         </BtnWrapper>
 
         <ListWrapper>

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -4,6 +4,7 @@ import Header from "../../components/Header/Header";
 import Search from "../../components/Search/Search";
 import ProductCard from "../../components/ProductCard/ProductCard";
 import { fetchProducts } from "../../assets/libs/api";
+import Button from "../../components/Button/Button";
 
 const Wrapper = styled.div`
   position: relative;
@@ -65,6 +66,51 @@ const ListWrapper = styled.div`
   }
 `;
 
+const BtnWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 2rem 0 1.2rem 0;
+`;
+
+const UpText = styled.p`
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  font-weight: 600;
+  color: #4f5153;
+  cursor: pointer;
+
+  @media screen and (max-width: 359px) {
+    font-size: 0.88rem;
+  }
+
+  @media screen and (min-width: 360px) and (max-width: 389px) {
+    font-size: 1rem;
+  }
+
+  @media screen and (min-width: 390px) and (max-width: 667px) {
+    font-size: 1.4rem;
+  }
+
+  @media screen and (min-width: 668px) and (max-width: 1023px) {
+    font-size: 1.2rem;
+  }
+
+  @media screen and (min-width: 1024px) {
+    font-size: 1.32rem;
+  }
+
+  @media screen and (min-width: 1280px) {
+    font-size: 1.36rem;
+  }
+`;
+
 interface Product {
   id: number;
   title: string;
@@ -87,18 +133,29 @@ const Main: React.FC = () => {
   const [products, setProducts] = useState<Product[]>([]);
 
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data: ProductResponse = await fetchProducts();
-        setProducts(data.products);
-      } catch (error) {
-        console.error("Error fetching products:", error);
-      }
-    };
     fetchData();
   }, []);
 
-  //   console.log("데이터:", products);
+  const fetchData = async () => {
+    try {
+      const data: ProductResponse = await fetchProducts();
+      setProducts(data.products.slice(0, 10));
+    } catch (error) {
+      console.error("Error fetching:", error);
+    }
+  };
+
+  const loadMore = async () => {
+    try {
+      const data: ProductResponse = await fetchProducts();
+      setProducts((prevProducts) => [
+        ...prevProducts,
+        ...data.products.slice(prevProducts.length, prevProducts.length + 10),
+      ]);
+    } catch (error) {
+      console.error("Error loading:", error);
+    }
+  };
 
   return (
     <div>
@@ -117,6 +174,18 @@ const Main: React.FC = () => {
             />
           ))}
         </ListWrapper>
+        <BtnWrapper>
+          {products.length === 100 ? (
+            <UpText
+              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+            >
+              👆
+              <br />맨 위로 이동하기
+            </UpText>
+          ) : (
+            <Button text="더보기" onClick={loadMore} />
+          )}
+        </BtnWrapper>
       </Wrapper>
     </div>
   );


### PR DESCRIPTION
### 메인페이지에 상품 10개 보여진 상태에서 '더보기' 버튼 누를 시 10개씩 상품 데이터 추출 작업 진행
- dummy API fetch할 때 limit=100으로 설정하여 total 상품 데이터 불러오도록 구성
- Main 페이지에서 `useState`, `useEffect`를 사용하여 초기에는 fetch한 100개의 데이터 중에서 10개만 표시
- 이후 '더보기' 버튼을 클릭 시 loadMore 함수를 통해, 새로운 데이터 10개씩 누적하여 표시하도록 로직 구현
- 모든 데이터 100개를 표시를 완료할 때, '더보기' 버튼 대신에 '맨 위로 이동' 버튼으로 대체하여 `scrollTo`를 사용하여 상단 스크롤로 이동하도록 <strong>UX 개선</strong>

![2024-04-181 19 40-ezgif com-speed](https://github.com/hyunjoebrother/baecomm-task-fe/assets/66728383/c2b7b1c8-9df2-49d0-b0fe-9397a88e1b9f)
