### PR TITLE
feat: save Scroll Info by local storage logic

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -68,9 +68,13 @@ const Text = styled.h3`
 `;
 
 const Header: React.FC = () => {
+  const refreshScroll = () => {
+    localStorage.setItem("isVisitInfoPage", "false");
+    localStorage.setItem("scrollPosition", "0");
+  };
   return (
     <Wrapper>
-      <HeaderLink to="/">
+      <HeaderLink to="/" onClick={refreshScroll}>
         <Text>Marketz</Text>
       </HeaderLink>
     </Wrapper>

--- a/src/components/ProductCard/ProductCard.tsx
+++ b/src/components/ProductCard/ProductCard.tsx
@@ -8,6 +8,7 @@ interface ProductCardProps {
   price: number;
   brand: string;
   thumbnail: string;
+  onClick: () => void;
 }
 
 const CardLink = styled(Link)`
@@ -219,9 +220,14 @@ const ProductCard: React.FC<ProductCardProps> = ({
   brand,
   title,
   price,
+  onClick,
 }) => {
+  const handleClick = () => {
+    onClick();
+  };
+
   return (
-    <CardLink to={`/info/${id}`}>
+    <CardLink to={`/info/${id}`} onClick={handleClick}>
       <Wrapper>
         <ImageWrapper>
           <ImageSrc src={thumbnail} />

--- a/src/pages/Info/Info.tsx
+++ b/src/pages/Info/Info.tsx
@@ -267,15 +267,19 @@ const Info: React.FC = () => {
   }, [id]);
 
   if (!product) {
-    return null; // 상품 정보가 없을 경우 아무것도 렌더링하지 않습니다.
+    return null;
   }
+
+  const handleGoBack = () => {
+    localStorage.setItem("isVisitInfoPage", "true");
+  };
 
   return (
     <div>
       <Header />
       <Wrapper>
         <BtnWrapper>
-          <BtnLink to="/">
+          <BtnLink to="/" onClick={handleGoBack}>
             <Button text="목록으로 돌아가기" />
           </BtnLink>
         </BtnWrapper>

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -138,6 +138,14 @@ const Main: React.FC = () => {
     fetchData();
   }, []);
 
+  useEffect(() => {
+    let savedVisitedInfo = localStorage.getItem("isVisitInfoPage");
+    let savedScrollPosition = localStorage.getItem("scrollPosition");
+    if (savedVisitedInfo === "true") {
+      window.scrollTo(0, parseInt(savedScrollPosition || "0"));
+    }
+  }, []);
+
   const fetchData = async () => {
     try {
       const data: ProductResponse = await fetchProducts();
@@ -155,7 +163,6 @@ const Main: React.FC = () => {
       const data: ProductResponse = await response.json();
       setSearchItem(searchItem);
       setSearchResults(data.products);
-      console.log("검색 결과:", data);
     } catch (error) {
       console.error("Error searching:", error);
     }
@@ -173,6 +180,11 @@ const Main: React.FC = () => {
     }
   };
 
+  const handleSaveScroll = () => {
+    const scrollPosition = window.scrollY;
+    localStorage.setItem("scrollPosition", scrollPosition.toString());
+  };
+
   return (
     <div>
       <Header />
@@ -187,6 +199,7 @@ const Main: React.FC = () => {
               title={product.title}
               brand={product.brand}
               price={product.price}
+              onClick={handleSaveScroll}
             />
           ))}
           {searchItem && searchResults.length === 0 && (


### PR DESCRIPTION
### Local Storage를 사용하여 스크롤 위치 및 상태 저장 작업 진행
1. **메인 페이지 (/)에서 상품 (ProductCard) 를 클릭 시,**
- _`window.scrollY`를 통해 현재 스크롤 높이 정보를 로컬스토리지 "scrollPosition"에 값 저장_
2. **상세 페이지 (/info)에서 '목록으로 돌아가기' 버튼을 클릭 시,**
- _로컬스토리지에 상세 페이지 방문 여부 "isVisitInfoPage"에 "true" 값 저장_
3. **다시 메인 페이지 (/)로 돌아올 시,**
- _로컬스토리지에서 상세 페이지 방문 여부를 확인 후 "isVisitInfoPage"가 "true"라면 "scrollPosition"에 해당하는 스크롤 위치로 이동하도록 구현_
4. **페이지를 새로고침하거나, 헤더의 로고를 클릭 시,**
- _로컬스토리지의 상세 페이지 방문 여부 값 "isVisitInfoPage"를 "false"로 초기화, 현재 스크롤 높이 값 "scrollPosition"를 0으로 초기화_